### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.7.0] - 2023-11-28
 
@@ -59,7 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Leverage app platform for deploying teleport-kube-agent app
-
 
 ## [0.1.0] - 2023-08-09
 

--- a/helm/teleport-operator/values.yaml
+++ b/helm/teleport-operator/values.yaml
@@ -5,7 +5,7 @@ global:
 image:
   name: "giantswarm/teleport-operator"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 teleport:
   appCatalog: giantswarm


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
