### PR TITLE
Do not push to Vintage (aws-app-collection)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,21 +36,6 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
-          name: aws-app-collection
-          context: "architect"
-          app_name: "teleport-operator"
-          app_namespace: "giantswarm"
-          app_collection_repo: "aws-app-collection"
-          requires:
-            - push-teleport-operator-to-app-catalog
-            - push-to-registries
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
           context: architect
           name: push-to-capa-app-collection
           app_name: "teleport-operator"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove CircleCI push to Vintage (aws-app-collection)
+
 ## [0.7.0] - 2023-11-28
 
 ### Changed


### PR DESCRIPTION
https://gigantic.slack.com/archives/C02HLSDH3DZ/p1702461475038039

- We haven’t rolled out Teleport on vintage and we only have it on CAPI, so shouldn’t be running there.

Also, remove `teleport-operator.yaml` from aws-app-collection repo and remove it's reference from kustomization.yaml 

### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.
