### PR TITLE
add CiliumNetworkPolicy (disabled by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `CiliumNetworkPolicy` (disabled by default).
+
 ### Changed
 
 - Configure `gsoci.azurecr.io` as the default container image registry.

--- a/helm/teleport-operator/templates/networkpolicy.yaml
+++ b/helm/teleport-operator/templates/networkpolicy.yaml
@@ -1,3 +1,22 @@
+{{- if .Values.ciliumNetworkPolicy.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "resource.networkPolicy.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+  ingress:
+  - toPorts:
+    - 8080/tcp
+  endpointSelector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+{{- else }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -18,3 +37,4 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+{{- end }}

--- a/helm/teleport-operator/values.schema.json
+++ b/helm/teleport-operator/values.schema.json
@@ -15,6 +15,14 @@
                 }
             }
         },
+        "ciliumNetworkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/helm/teleport-operator/values.yaml
+++ b/helm/teleport-operator/values.yaml
@@ -2,6 +2,9 @@ global:
   podSecurityStandards:
     enforced: false
 
+ciliumNetworkPolicy:
+  enabled: false
+
 image:
   name: "giantswarm/teleport-operator"
 registry:


### PR DESCRIPTION
this PR:

- adds a `CiliumNetworkPolicy` which replicates the existing netpol whilst also allowing egress to the kubernetes api server.

This is required when running in MCs where deny-all policies are enforced by default in `giantswarm` and `kube-system` namespaces:

```
ERROR: Get "https://100.64.0.1:443/api/v1/namespaces/giantswarm/secrets/identity-output": dial tcp 100.64.0.1:443: i/o timeout
```

I've retained the default behaviour of the chart by ensuring that the standard k8s netpol is created unless the Cilium netpol is explicitly enabled.
