### PR TITLE
fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test
-teleport-operator
+./teleport-operator
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Configure `gsoci.azurecr.io` as the default container image registry.
+- Correct path in `.gitignore`.
 
 ### Changed
 


### PR DESCRIPTION
This PR:

- fixes the path for the built binary. previously it also matched the `helm/teleport-operator` directory which is incorrect.
