### PR TITLE
Set `TELEPORT_TLS_ROUTING_CONN_UPGRADE` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set `TELEPORT_TLS_ROUTING_CONN_UPGRADE` environment variable
+
 ## [0.8.2] - 2024-01-04
 
 ### Added

--- a/helm/teleport-operator/templates/deployment.yaml
+++ b/helm/teleport-operator/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
       containers:
       - name: {{ .Chart.Name }}
+        env:
+        - name: TELEPORT_TLS_ROUTING_CONN_UPGRADE
+          value: "{{ .Values.teleport.proxyAddr }}=yes"
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Chart.Version }}"
         args:
         - "--namespace={{ include "resource.default.namespace"  . }}"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3077

As encountered in `gerbil` MC, we need to explicitly set `TELEPORT_TLS_ROUTING_CONN_UPGRADE` for teleport-operator to work in private cluster setup.

### What this PR does / why we need it

- Adds environment variable `TELEPORT_TLS_ROUTING_CONN_UPGRADE` to `teleport-operator` deployment.

### Checklist

- [x] Update changelog in CHANGELOG.md.
