### PR TITLE
Add `world` to Cilium Network Policy `toEntities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated cilium network policy for tbot and teleport-operator
+
 ## [0.8.3] - 2024-01-04
 
 ### Added

--- a/helm/teleport-operator/templates/networkpolicy.yaml
+++ b/helm/teleport-operator/templates/networkpolicy.yaml
@@ -10,6 +10,7 @@ spec:
   egress:
   - toEntities:
     - kube-apiserver
+    - world
   ingress:
   - toPorts:
     - port: "8080"

--- a/helm/teleport-operator/templates/tbot-networkpolicy.yaml
+++ b/helm/teleport-operator/templates/tbot-networkpolicy.yaml
@@ -10,6 +10,7 @@ spec:
   egress:
   - toEntities:
     - kube-apiserver
+    - world
   ingress:
   - toPorts:
     - port: "8080"


### PR DESCRIPTION
### What this PR does / why we need it

- Adds `world` to Cilium Network Policy `toEntities` to allow tbot and teleport-operator pod to communicates with teleport cluster (teleport.giantswarm.io:443)

### Checklist

- [x] Update changelog in CHANGELOG.md.
