### PR TITLE
Increase token validity for node and kube agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase token validity for node and kube agents
+
 ## [0.9.2] - 2024-05-07
 
 ### Added

--- a/internal/pkg/key/key.go
+++ b/internal/pkg/key/key.go
@@ -13,8 +13,8 @@ const (
 	TeleportOperatorLabelValue      = "teleport-operator"
 	TeleportOperatorConfigName      = "teleport-operator"
 	TeleportBotSecretName           = "identity-output"
-	TeleportKubeTokenValidity       = 1 * time.Hour
-	TeleportNodeTokenValidity       = 24 * time.Hour
+	TeleportKubeTokenValidity       = 720 * time.Hour
+	TeleportNodeTokenValidity       = 720 * time.Hour
 
 	AppCatalog            = "appCatalog"
 	AppName               = "appName"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30290

### What this PR does / why we need it
- Increases token validity for node and kube agent to a month, see above issue for more details.

### Checklist

- [x] Update changelog in CHANGELOG.md.
