### PR TITLE
Disable zap logger development mode to avoid panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Disable logger development mode to avoid panicking
 - Chart to use `.Release.Namespace` namespace
 
 ## [0.10.0] - 2024-08-19

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 			"Enabling this will ensure teleport bot configmap is created and app.spec.extraConfig is updated.")
 	flag.StringVar(&namespace, "namespace", "", "Namespace where operator is deployed")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
### What this PR does / why we need it

This PR:
### Fixes
- Disables zap logger development mode to avoid panicking


- [x] Update changelog in CHANGELOG.md.
