### PR TITLE
Implement multiple roles per token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Implemented option to generate combined `kube` & `app` tokens
 - Change ownership to Team Shield
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Implemented option to generate combined `kube` & `app` tokens
+- Implemented option to generate combined tokens with multiple roles
 - Change ownership to Team Shield
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,5 @@ FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
-ENV USE_COMBINED_TOKENS="false"
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
+ENV USE_COMBINED_TOKENS="false"
 
 ENTRYPOINT ["/manager"]

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.0
 	github.com/onsi/gomega v1.34.1
 	github.com/pkg/errors v0.9.1
-	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
@@ -92,6 +91,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.28.0 // indirect

--- a/helm/teleport-operator/templates/deployment.yaml
+++ b/helm/teleport-operator/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
         env:
         - name: TELEPORT_TLS_ROUTING_CONN_UPGRADE
           value: "{{ .Values.teleport.proxyAddr }}=yes"
+        - name: USE_COMBINED_TOKENS
+          value: {{ .Values.teleportOperator.useCombinedTokens | quote }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Chart.Version }}"
         args:
         - "--namespace={{ include "resource.default.namespace"  . }}"

--- a/helm/teleport-operator/templates/deployment.yaml
+++ b/helm/teleport-operator/templates/deployment.yaml
@@ -33,8 +33,6 @@ spec:
         env:
         - name: TELEPORT_TLS_ROUTING_CONN_UPGRADE
           value: "{{ .Values.teleport.proxyAddr }}=yes"
-        - name: USE_COMBINED_TOKENS
-          value: {{ .Values.teleportOperator.useCombinedTokens | quote }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Chart.Version }}"
         args:
         - "--namespace={{ include "resource.default.namespace" . }}"

--- a/helm/teleport-operator/templates/deployment.yaml
+++ b/helm/teleport-operator/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         {{- include "labels.selector" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "resource.default.name"  . }}
+      serviceAccountName: {{ include "resource.default.name" . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
@@ -37,7 +37,8 @@ spec:
           value: {{ .Values.teleportOperator.useCombinedTokens | quote }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Chart.Version }}"
         args:
-        - "--namespace={{ include "resource.default.namespace"  . }}"
+        - "--namespace={{ include "resource.default.namespace" . }}"
+        - "--roles={{ .Values.teleportOperator.roles | join "," }}"
         {{- if .Values.tbot.enabled }}
         - "--tbot"
         {{- end }}

--- a/helm/teleport-operator/templates/deployment.yaml
+++ b/helm/teleport-operator/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Chart.Version }}"
         args:
         - "--namespace={{ include "resource.default.namespace" . }}"
-        - "--roles={{ .Values.teleportOperator.roles | join "," }}"
+        - "--token-roles={{ .Values.teleportOperator.roles | join "," }}"
         {{- if .Values.tbot.enabled }}
         - "--tbot"
         {{- end }}

--- a/helm/teleport-operator/values.schema.json
+++ b/helm/teleport-operator/values.schema.json
@@ -63,6 +63,14 @@
                 }
             }
         },
+        "teleportOperator": {
+            "type": "object",
+            "properties": {
+                "useCombinedTokens": {
+                    "type": "boolean"
+                }
+            }
+        },
         "pod": {
             "type": "object",
             "properties": {

--- a/helm/teleport-operator/values.schema.json
+++ b/helm/teleport-operator/values.schema.json
@@ -66,11 +66,16 @@
         "teleportOperator": {
             "type": "object",
             "properties": {
-                "useCombinedTokens": {
-                    "type": "boolean"
-                }
-            }
-        },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of roles for the Teleport operator. Example: ['kube', 'app']"
+              }
+            },
+            "required": ["roles"]
+          },
         "pod": {
             "type": "object",
             "properties": {

--- a/helm/teleport-operator/values.yaml
+++ b/helm/teleport-operator/values.yaml
@@ -17,7 +17,10 @@ teleport:
   managementClusterName: ""
   proxyAddr: test.teleport.giantswarm.io:443
   teleportClusterName: test.teleport.giantswarm.io
-  teleportVersion: 15.1.7
+  teleportVersion: 16.1.7
+
+teleportOperator:
+  useCombinedTokens: true  # Set true if we want `kube, app` role tokens to be generated instead of just `kube` ones.
 
 pod:
   user:

--- a/helm/teleport-operator/values.yaml
+++ b/helm/teleport-operator/values.yaml
@@ -20,7 +20,9 @@ teleport:
   teleportVersion: 16.1.7
 
 teleportOperator:
-  useCombinedTokens: true  # Set true if we want `kube, app` role tokens to be generated instead of just `kube` ones.
+  roles:
+    - kube
+    - app
 
 pod:
   user:

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -206,7 +206,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err != nil {
 			return ctrl.Result{}, microerror.Mask(err)
 		}
-		if err := r.Teleport.CreateConfigMap(ctx, log, r.Client, cluster.Name, cluster.Namespace, registerName, token); err != nil {
+		if err := r.Teleport.CreateConfigMap(ctx, log, r.Client, cluster.Name, cluster.Namespace, registerName, token, tokenType); err != nil {
 			return ctrl.Result{}, microerror.Mask(err)
 		}
 	} else {
@@ -223,7 +223,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if err != nil {
 				return ctrl.Result{}, microerror.Mask(err)
 			}
-			if err := r.Teleport.UpdateConfigMap(ctx, log, r.Client, configMap, token); err != nil {
+			if err := r.Teleport.UpdateConfigMap(ctx, log, r.Client, configMap, token, tokenType); err != nil {
 				return ctrl.Result{}, microerror.Mask(err)
 			}
 		} else {

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -49,7 +49,7 @@ func Test_ClusterController(t *testing.T) {
 			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 		},
 		{
 			name:              "case 1: Register cluster and update Secret, ConfigMap and App resources in case they exist",
@@ -59,10 +59,10 @@ func Test_ClusterController(t *testing.T) {
 			identity:          newIdentity(test.LastReadValue),
 			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			secret:            test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 		},
 		{
 			name:              "case 2: Update Secret and ConfigMap resources in case join token changes",
@@ -72,10 +72,10 @@ func Test_ClusterController(t *testing.T) {
 			identity:          newIdentity(test.LastReadValue),
 			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			secret:            test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.NewTokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, "kube,app"),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{"kube", "app"}),
 		},
 		{
 			name:      "case 3: Deregister cluster and delete resources in case the cluster is deleted",
@@ -85,7 +85,7 @@ func Test_ClusterController(t *testing.T) {
 			identity:  newIdentity(test.LastReadValue),
 			cluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Now()),
 			secret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 		},
 		{
 			name:           "case 4: Reconnect to Teleport when credentials are rotated",
@@ -96,13 +96,13 @@ func Test_ClusterController(t *testing.T) {
 			cluster:        test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			secret:         test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
 			identitySecret: test.NewIdentitySecret(test.NamespaceName, test.IdentityFileValue),
-			configMap:      test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap:      test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			newTeleportClient: func(ctx context.Context, proxyAddr, identityFile string) (teleport.Client, error) {
 				return test.NewTeleportClient(test.FakeTeleportClientConfig{Tokens: nil}), nil
 			},
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.NewTokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, "kube,app"),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{"kube", "app"}),
 		},
 		{
 			name:      "case 5: Return an error in case reconnection to Teleport fails after the credentials are rotated",
@@ -112,7 +112,7 @@ func Test_ClusterController(t *testing.T) {
 			identity:  newIdentity(time.Now().Add(-identityExpirationPeriod - time.Second)),
 			cluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			secret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			newTeleportClient: func(ctx context.Context, proxyAddr, identityFile string) (teleport.Client, error) {
 				return nil, errors.New("simulated error")
 			},
@@ -153,12 +153,13 @@ func Test_ClusterController(t *testing.T) {
 			log := ctrl.Log.WithName("test")
 
 			controller := &ClusterReconciler{
-				Client:            ctrlClient,
-				Log:               log,
-				Scheme:            scheme.Scheme,
-				Namespace:         tc.namespace,
-				Teleport:          teleport.New(tc.namespace, tc.config, test.NewMockTokenGenerator(tc.token)),
-				UseCombinedTokens: true,
+				Client:       ctrlClient,
+				Log:          log,
+				Scheme:       scheme.Scheme,
+				Namespace:    tc.namespace,
+				Teleport:     teleport.New(tc.namespace, tc.config, test.NewMockTokenGenerator(tc.token)),
+				IsBotEnabled: false,
+				TokenRoles:   []string{"kube", "app"},
 			}
 			controller.Teleport.TeleportClient = test.NewTeleportClient(test.FakeTeleportClientConfig{
 				Tokens: tc.tokens,

--- a/internal/pkg/key/key.go
+++ b/internal/pkg/key/key.go
@@ -57,8 +57,8 @@ func GetAppName(clusterName string, appName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, appName)
 }
 
-func GetConfigmapDataFromTemplate(authToken string, proxyAddr string, kubeClusterName string, teleportVersion string) string {
-	dataTpl := `roles: "kube,app"
+func GetConfigmapDataFromTemplate(authToken string, proxyAddr string, kubeClusterName string, teleportVersion string, roles string) string {
+	dataTpl := `roles: "%s"
 authToken: "%s"
 proxyAddr: "%s"
 kubeClusterName: "%s"
@@ -68,7 +68,7 @@ kubeClusterName: "%s"
 		dataTpl = fmt.Sprintf("%steleportVersionOverride: %q", dataTpl, teleportVersion)
 	}
 
-	return fmt.Sprintf(dataTpl, authToken, proxyAddr, kubeClusterName)
+	return fmt.Sprintf(dataTpl, roles, authToken, proxyAddr, kubeClusterName)
 }
 
 func GetTbotConfigmapDataFromTemplate(kubeClusterName string, clusterName string) string {

--- a/internal/pkg/key/key.go
+++ b/internal/pkg/key/key.go
@@ -15,6 +15,7 @@ const (
 	TeleportBotSecretName           = "identity-output"
 	TeleportBotNamespace            = "giantswarm"
 	TeleportBotAppName              = "teleport-tbot"
+	TeleportAppTokenValidity        = 720 * time.Hour
 	TeleportKubeTokenValidity       = 720 * time.Hour
 	TeleportNodeTokenValidity       = 720 * time.Hour
 
@@ -57,7 +58,7 @@ func GetAppName(clusterName string, appName string) string {
 }
 
 func GetConfigmapDataFromTemplate(authToken string, proxyAddr string, kubeClusterName string, teleportVersion string) string {
-	dataTpl := `roles: "kube"
+	dataTpl := `roles: "kube,app"
 authToken: "%s"
 proxyAddr: "%s"
 kubeClusterName: "%s"

--- a/internal/pkg/teleport/configmap.go
+++ b/internal/pkg/teleport/configmap.go
@@ -68,11 +68,11 @@ func (t *Teleport) GetTokenFromConfigMap(ctx context.Context, configMap *corev1.
 	return token, nil
 }
 
-func (t *Teleport) CreateConfigMap(ctx context.Context, log logr.Logger, ctrlClient client.Client, clusterName string, clusterNamespace string, registerName string, token string) error {
+func (t *Teleport) CreateConfigMap(ctx context.Context, log logr.Logger, ctrlClient client.Client, clusterName string, clusterNamespace string, registerName string, token string, tokenType string) error {
 	configMapName := key.GetConfigmapName(clusterName, t.Config.AppName)
 
 	configMapData := map[string]string{
-		"values": t.getConfigMapData(registerName, token),
+		"values": t.getConfigMapData(registerName, token, tokenType),
 	}
 
 	cm := corev1.ConfigMap{}
@@ -137,7 +137,7 @@ func (t *Teleport) EnsureTbotConfigMap(ctx context.Context, log logr.Logger, ctr
 	return nil
 }
 
-func (t *Teleport) UpdateConfigMap(ctx context.Context, log logr.Logger, ctrlClient client.Client, configMap *corev1.ConfigMap, token string) error {
+func (t *Teleport) UpdateConfigMap(ctx context.Context, log logr.Logger, ctrlClient client.Client, configMap *corev1.ConfigMap, token string, tokenType string) error {
 	valuesBytes, ok := configMap.Data["values"]
 	if !ok {
 		return microerror.Mask(fmt.Errorf("malformed ConfigMap: key `values` not found"))
@@ -150,6 +150,11 @@ func (t *Teleport) UpdateConfigMap(ctx context.Context, log logr.Logger, ctrlCli
 
 	// Modify the authToken value
 	valuesYaml["authToken"] = token
+	if tokenType == "kubeapp" {
+		valuesYaml["roles"] = "kube,app"
+	} else {
+		valuesYaml["roles"] = "kube"
+	}
 
 	updatedValuesYaml, err := yaml.Marshal(valuesYaml)
 	if err != nil {
@@ -205,15 +210,20 @@ func (t *Teleport) DeleteTbotConfigMap(ctx context.Context, log logr.Logger, ctr
 	return nil
 }
 
-func (t *Teleport) getConfigMapData(registerName string, token string) string {
+func (t *Teleport) getConfigMapData(registerName string, token string, tokenType string) string {
 	var (
 		authToken               = token
 		proxyAddr               = t.Config.ProxyAddr
 		kubeClusterName         = registerName
 		teleportVersionOverride = t.Config.TeleportVersion
+		roles                   = "kube"
 	)
 
-	return key.GetConfigmapDataFromTemplate(authToken, proxyAddr, kubeClusterName, teleportVersionOverride)
+	if tokenType == "kubeapp" {
+		roles = "kube,app"
+	}
+
+	return key.GetConfigmapDataFromTemplate(authToken, proxyAddr, kubeClusterName, teleportVersionOverride, roles)
 }
 
 func (t *Teleport) getTbotConfigMapData(registerName string, clusterName string) string {

--- a/internal/pkg/teleport/configmap_test.go
+++ b/internal/pkg/teleport/configmap_test.go
@@ -38,7 +38,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -50,8 +50,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
-			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectError:       false,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -64,8 +64,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:       test.NamespaceName,
 			clusterName:     test.ClusterName,
 			registerName:    key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -77,7 +77,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:       test.NamespaceName,
 			clusterName:     test.ClusterName,
 			registerName:    key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectEmpty:     true,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -91,8 +91,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			clusterName:     test.ClusterName,
 			registerName:    key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			token:           test.TokenName,
-			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -111,7 +111,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 					Namespace: test.NamespaceName,
 				},
 			},
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectError:     true,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -125,8 +125,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			token:             test.NewTokenName,
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
-			configMapToUpdate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, "kube,app"),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMapToUpdate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{"kube", "app"}),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -138,8 +138,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
-			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectError:       false,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -152,7 +152,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectError:       false,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -201,7 +201,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			}
 
 			if tc.configMapToCreate != nil {
-				err = teleport.CreateConfigMap(ctx, log, ctrlClient, tc.clusterName, tc.namespace, tc.registerName, tc.token, "kubeapp")
+				err = teleport.CreateConfigMap(ctx, log, ctrlClient, tc.clusterName, tc.namespace, tc.registerName, tc.token, []string{"kube", "app"})
 				test.CheckError(t, tc.expectError, err)
 				if err != nil {
 					actualConfigMap, err = loadConfigMap(ctx, ctrlClient, tc.configMapToCreate)
@@ -213,7 +213,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			}
 
 			if tc.configMapToUpdate != nil {
-				err = teleport.UpdateConfigMap(ctx, log, ctrlClient, tc.configMap, tc.token, "kubeapp")
+				err = teleport.UpdateConfigMap(ctx, log, ctrlClient, tc.configMap, tc.token, []string{"kube", "app"})
 				test.CheckError(t, tc.expectError, err)
 				if err != nil {
 					actualConfigMap, err = loadConfigMap(ctx, ctrlClient, tc.configMapToUpdate)

--- a/internal/pkg/teleport/configmap_test.go
+++ b/internal/pkg/teleport/configmap_test.go
@@ -38,7 +38,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -50,8 +50,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
-			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToCreate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			expectError:       false,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -64,8 +64,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:       test.NamespaceName,
 			clusterName:     test.ClusterName,
 			registerName:    key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -77,7 +77,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:       test.NamespaceName,
 			clusterName:     test.ClusterName,
 			registerName:    key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			expectEmpty:     true,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -91,8 +91,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			clusterName:     test.ClusterName,
 			registerName:    key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			token:           test.TokenName,
-			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMap:       test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -111,7 +111,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 					Namespace: test.NamespaceName,
 				},
 			},
-			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMapToRead: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			expectError:     true,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -125,8 +125,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			token:             test.NewTokenName,
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
-			configMapToUpdate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToUpdate: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, "kube,app"),
 			config: &config.Config{
 				AppName:         test.AppName,
 				ProxyAddr:       test.ProxyAddr,
@@ -138,8 +138,8 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
-			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
+			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			expectError:       false,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -152,7 +152,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			namespace:         test.NamespaceName,
 			clusterName:       test.ClusterName,
 			registerName:      key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName),
+			configMapToDelete: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, "kube,app"),
 			expectError:       false,
 			config: &config.Config{
 				AppName:         test.AppName,
@@ -201,7 +201,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			}
 
 			if tc.configMapToCreate != nil {
-				err = teleport.CreateConfigMap(ctx, log, ctrlClient, tc.clusterName, tc.namespace, tc.registerName, tc.token)
+				err = teleport.CreateConfigMap(ctx, log, ctrlClient, tc.clusterName, tc.namespace, tc.registerName, tc.token, "kubeapp")
 				test.CheckError(t, tc.expectError, err)
 				if err != nil {
 					actualConfigMap, err = loadConfigMap(ctx, ctrlClient, tc.configMapToCreate)
@@ -213,7 +213,7 @@ func Test_ConfigMapCRUD(t *testing.T) {
 			}
 
 			if tc.configMapToUpdate != nil {
-				err = teleport.UpdateConfigMap(ctx, log, ctrlClient, tc.configMap, tc.token)
+				err = teleport.UpdateConfigMap(ctx, log, ctrlClient, tc.configMap, tc.token, "kubeapp")
 				test.CheckError(t, tc.expectError, err)
 				if err != nil {
 					actualConfigMap, err = loadConfigMap(ctx, ctrlClient, tc.configMapToUpdate)

--- a/internal/pkg/teleport/token.go
+++ b/internal/pkg/teleport/token.go
@@ -38,6 +38,9 @@ func (t *Teleport) GenerateToken(ctx context.Context, registerName string, token
 	switch tokenType {
 	case "kube":
 		tokenValidity = time.Now().Add(key.TeleportKubeTokenValidity)
+		tokenRoles = []types.SystemRole{types.RoleKube}
+	case "kubeapp":
+		tokenValidity = time.Now().Add(key.TeleportKubeTokenValidity)
 		tokenRoles = []types.SystemRole{types.RoleKube, types.RoleApp}
 	case "node":
 		tokenValidity = time.Now().Add(key.TeleportNodeTokenValidity)

--- a/internal/pkg/teleport/token.go
+++ b/internal/pkg/teleport/token.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	tt "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types"
 
 	"github.com/giantswarm/microerror"
 
@@ -32,21 +32,21 @@ func (t *Teleport) IsTokenValid(ctx context.Context, registerName string, oldTok
 func (t *Teleport) GenerateToken(ctx context.Context, registerName string, tokenType string) (string, error) {
 	var (
 		tokenValidity time.Time
-		tokenRole     tt.SystemRole
+		tokenRoles    []types.SystemRole
 	)
 
 	switch tokenType {
 	case "kube":
 		tokenValidity = time.Now().Add(key.TeleportKubeTokenValidity)
-		tokenRole = tt.RoleKube
+		tokenRoles = []types.SystemRole{types.RoleKube, types.RoleApp}
 	case "node":
 		tokenValidity = time.Now().Add(key.TeleportNodeTokenValidity)
-		tokenRole = tt.RoleNode
+		tokenRoles = []types.SystemRole{types.RoleNode}
 	default:
 		return "", microerror.Mask(fmt.Errorf("token type %s is not supported", tokenType))
 	}
 
-	token, err := tt.NewProvisionToken(t.TokenGenerator.Generate(), []tt.SystemRole{tokenRole}, tokenValidity)
+	token, err := types.NewProvisionToken(t.TokenGenerator.Generate(), tokenRoles, tokenValidity)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/internal/pkg/teleport/token_test.go
+++ b/internal/pkg/teleport/token_test.go
@@ -2,7 +2,9 @@ package teleport
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport/api/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -15,35 +17,39 @@ import (
 
 func Test_GenerateToken(t *testing.T) {
 	testCases := []struct {
-		name          string
-		registerName  string
-		tokenType     string
-		failsList     bool
-		failsDelete   bool
-		failsUpsert   bool
-		expectError   bool
-		expectedToken types.ProvisionToken
+		name           string
+		registerName   string
+		tokenType      []string
+		failsList      bool
+		failsDelete    bool
+		failsUpsert    bool
+		expectError    bool
+		expectedRoles  []string
+		expectedExpiry time.Duration
 	}{
 		{
-			name:          "case 0: Generate a new kube token",
-			registerName:  key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			tokenType:     test.TokenTypeKube,
-			expectError:   false,
-			expectedToken: test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube),
+			name:           "case 0: Generate a new kube token",
+			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
+			tokenType:      []string{"kube"},
+			expectError:    false,
+			expectedRoles:  []string{"kube"},
+			expectedExpiry: 720 * time.Hour,
 		},
 		{
-			name:          "case 1: Generate a new node token",
-			registerName:  key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			tokenType:     test.TokenTypeNode,
-			expectError:   false,
-			expectedToken: test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeNode),
+			name:           "case 1: Generate a new node token",
+			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
+			tokenType:      []string{"node"},
+			expectError:    false,
+			expectedRoles:  []string{"node"},
+			expectedExpiry: 720 * time.Hour,
 		},
 		{
-			name:          "case 2: Generate a new kube and app token",
-			registerName:  key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			tokenType:     test.TokenTypeKubeApp,
-			expectError:   false,
-			expectedToken: test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKubeApp),
+			name:           "case 2: Generate a new kube and app token",
+			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
+			tokenType:      []string{"kube", "app"},
+			expectError:    false,
+			expectedRoles:  []string{"kube", "app"},
+			expectedExpiry: 720 * time.Hour,
 		},
 		{
 			name:         "case 3: Fail in case new token cannot be upserted",
@@ -73,7 +79,28 @@ func Test_GenerateToken(t *testing.T) {
 			generatedToken, err := teleport.TeleportClient.GetToken(ctx, tokenName)
 			test.CheckError(t, false, err)
 			if err == nil {
-				test.CheckToken(t, tc.expectedToken, generatedToken)
+				expectedExpiryTime := time.Now().Add(tc.expectedExpiry)
+
+				actualToken := generatedToken.(*types.ProvisionTokenV2)
+				if !actualToken.GetMetadata().Expires.After(expectedExpiryTime.Add(-time.Minute)) ||
+					!actualToken.GetMetadata().Expires.Before(expectedExpiryTime.Add(time.Minute)) {
+					t.Fatalf("Expected token expiry to be close to %v, but got %v", expectedExpiryTime, actualToken.GetMetadata().Expires)
+				}
+
+				actualRoles := actualToken.GetRoles()
+				actualRoleStrings := make([]string, len(actualRoles))
+				for i, role := range actualRoles {
+					actualRoleStrings[i] = strings.ToLower(role.String())
+				}
+
+				if len(tc.expectedRoles) != len(actualRoleStrings) {
+					t.Fatalf("Expected roles %v, but got %v", tc.expectedRoles, actualRoleStrings)
+				}
+				for i := range tc.expectedRoles {
+					if tc.expectedRoles[i] != actualRoleStrings[i] {
+						t.Fatalf("Expected roles %v, but got %v", tc.expectedRoles, actualRoleStrings)
+					}
+				}
 			}
 		})
 	}
@@ -95,7 +122,7 @@ func Test_IsTokenValid(t *testing.T) {
 			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			tokenName:      test.TokenName,
 			tokenType:      test.TokenTypeKube,
-			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube)},
+			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"})},
 			expectedResult: true,
 		},
 		{
@@ -111,7 +138,7 @@ func Test_IsTokenValid(t *testing.T) {
 			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			tokenName:      test.TokenName,
 			tokenType:      test.TokenTypeNode,
-			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube)},
+			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"})},
 			expectedResult: false,
 		},
 		{
@@ -156,28 +183,28 @@ func Test_DeleteToken(t *testing.T) {
 		{
 			name:          "case 0: Delete token from Teleport",
 			registerName:  key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			token:         test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube),
-			tokens:        []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube)},
+			token:         test.NewToken(test.TokenName, test.ClusterName, []string{"kube"}),
+			tokens:        []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"})},
 			expectDeleted: true,
 		},
 		{
 			name:          "case 1: Do not delete token in case cluster label does not match",
 			registerName:  test.ManagementClusterName,
-			token:         test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube),
-			tokens:        []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube)},
+			token:         test.NewToken(test.TokenName, test.ClusterName, []string{"kube"}),
+			tokens:        []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"})},
 			expectDeleted: false,
 		},
 		{
 			name:          "case 2: Succeed in case token does not exist",
 			registerName:  key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			token:         test.NewToken(test.TokenName, test.ManagementClusterName, test.TokenTypeKube),
+			token:         test.NewToken(test.TokenName, test.ManagementClusterName, []string{"kube"}),
 			expectDeleted: true,
 		},
 		{
 			name:         "case 3: Fail in case teleport client is unable to delete the token",
 			registerName: key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
-			token:        test.NewToken(test.TokenName, test.ManagementClusterName, test.TokenTypeKube),
-			tokens:       []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKube)},
+			token:        test.NewToken(test.TokenName, test.ManagementClusterName, []string{"kube"}),
+			tokens:       []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"})},
 			failsDelete:  true,
 			expectError:  true,
 		},

--- a/internal/pkg/teleport/token_test.go
+++ b/internal/pkg/teleport/token_test.go
@@ -39,6 +39,13 @@ func Test_GenerateToken(t *testing.T) {
 			expectedToken: test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeNode),
 		},
 		{
+			name:          "case 2: Generate a new kube and app token",
+			registerName:  key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
+			tokenType:     test.TokenTypeKubeApp,
+			expectError:   false,
+			expectedToken: test.NewToken(test.TokenName, test.ClusterName, test.TokenTypeKubeApp),
+		},
+		{
 			name:         "case 3: Fail in case new token cannot be upserted",
 			registerName: key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			failsUpsert:  true,

--- a/internal/pkg/test/resources.go
+++ b/internal/pkg/test/resources.go
@@ -39,7 +39,7 @@ const (
 	IdentityFileValue     = "identity-file-value"
 	TeleportVersion       = "1.0.0"
 
-	ConfigMapValuesFormat = "authToken: %s\nproxyAddr: %s\nroles: kube,app\nkubeClusterName: %s\nteleportVersionOverride: %s"
+	ConfigMapValuesFormat = "authToken: %s\nproxyAddr: %s\nroles: %s\nkubeClusterName: %s\nteleportVersionOverride: %s"
 )
 
 var LastReadValue = time.Now()
@@ -81,7 +81,7 @@ func NewIdentitySecret(namespaceName, identityFile string) *corev1.Secret {
 	}
 }
 
-func NewConfigMap(clusterName, appName, namespaceName, tokenName string) *corev1.ConfigMap {
+func NewConfigMap(clusterName, appName, namespaceName, tokenName, roles string) *corev1.ConfigMap {
 	registerName := key.GetRegisterName(ManagementClusterName, clusterName)
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -89,7 +89,7 @@ func NewConfigMap(clusterName, appName, namespaceName, tokenName string) *corev1
 			Namespace: namespaceName,
 		},
 		Data: map[string]string{
-			"values": fmt.Sprintf(ConfigMapValuesFormat, tokenName, ProxyAddr, registerName, TeleportVersion),
+			"values": fmt.Sprintf(ConfigMapValuesFormat, tokenName, ProxyAddr, roles, registerName, TeleportVersion),
 		},
 	}
 }

--- a/internal/pkg/test/resources.go
+++ b/internal/pkg/test/resources.go
@@ -28,8 +28,9 @@ const (
 	TokenTypeKey  = "type"
 	JoinTokenKey  = "joinToken"
 
-	TokenTypeKube = "kube"
-	TokenTypeNode = "node"
+	TokenTypeKube    = "kube"
+	TokenTypeNode    = "node"
+	TokenTypeKubeApp = "kubeapp"
 
 	AppCatalog            = "app-catalog"
 	AppVersion            = "appVersion"
@@ -38,7 +39,7 @@ const (
 	IdentityFileValue     = "identity-file-value"
 	TeleportVersion       = "1.0.0"
 
-	ConfigMapValuesFormat = "authToken: %s\nproxyAddr: %s\nroles: kube\nkubeClusterName: %s\nteleportVersionOverride: %s"
+	ConfigMapValuesFormat = "authToken: %s\nproxyAddr: %s\nroles: kube,app\nkubeClusterName: %s\nteleportVersionOverride: %s"
 )
 
 var LastReadValue = time.Now()
@@ -106,10 +107,13 @@ func NewToken(tokenName, clusterName, tokenType string) teleportTypes.ProvisionT
 			Roles: []teleportTypes.SystemRole{},
 		},
 	}
-	if tokenType == TokenTypeKube {
+	switch tokenType {
+	case TokenTypeKube:
 		newToken.Spec.Roles = append(newToken.Spec.Roles, teleportTypes.RoleKube)
-	} else if tokenType == TokenTypeNode {
+	case TokenTypeNode:
 		newToken.Spec.Roles = append(newToken.Spec.Roles, teleportTypes.RoleNode)
+	case TokenTypeKubeApp:
+		newToken.Spec.Roles = append(newToken.Spec.Roles, teleportTypes.RoleKube, teleportTypes.RoleApp)
 	}
 	return newToken
 }

--- a/internal/pkg/test/resources.go
+++ b/internal/pkg/test/resources.go
@@ -29,9 +29,9 @@ const (
 	TokenTypeKey  = "type"
 	JoinTokenKey  = "joinToken"
 
-	TokenTypeKube    = "kube"
-	TokenTypeNode    = "node"
-	TokenTypeKubeApp = "kubeapp"
+	TokenTypeKube = "kube"
+	TokenTypeNode = "node"
+	TokenTypeApp  = "app"
 
 	AppCatalog            = "app-catalog"
 	AppVersion            = "appVersion"

--- a/internal/pkg/test/teleport_client_test.go
+++ b/internal/pkg/test/teleport_client_test.go
@@ -41,13 +41,13 @@ func Test_FakeTeleportClient(t *testing.T) {
 			name: "case 2: Return expected list of tokens",
 			config: FakeTeleportClientConfig{
 				Tokens: []types.ProvisionToken{
-					NewToken(TokenName, ClusterName, TokenTypeKube),
-					NewToken(NewTokenName, ClusterName, TokenTypeKube),
+					NewToken(TokenName, ClusterName, []string{"kube"}),
+					NewToken(NewTokenName, ClusterName, []string{"kube"}),
 				},
 			},
 			expectedTokens: []types.ProvisionToken{
-				NewToken(TokenName, ClusterName, TokenTypeKube),
-				NewToken(NewTokenName, ClusterName, TokenTypeKube),
+				NewToken(TokenName, ClusterName, []string{"kube"}),
+				NewToken(NewTokenName, ClusterName, []string{"kube"}),
 			},
 			expectClientErrors: false,
 		},
@@ -55,8 +55,8 @@ func Test_FakeTeleportClient(t *testing.T) {
 			name: "case 3, Fail to return list of tokens",
 			config: FakeTeleportClientConfig{
 				Tokens: []types.ProvisionToken{
-					NewToken(TokenName, ClusterName, TokenTypeKube),
-					NewToken(NewTokenName, ClusterName, TokenTypeKube),
+					NewToken(TokenName, ClusterName, []string{"kube"}),
+					NewToken(NewTokenName, ClusterName, []string{"kube"}),
 				},
 			},
 			expectClientErrors: false,
@@ -66,18 +66,18 @@ func Test_FakeTeleportClient(t *testing.T) {
 			name: "case 4: Return expected token",
 			config: FakeTeleportClientConfig{
 				Tokens: []types.ProvisionToken{
-					NewToken(TokenName, ClusterName, TokenTypeKube),
+					NewToken(TokenName, ClusterName, []string{"kube"}),
 				},
 			},
 			tokenName:          TokenName,
-			expectedToken:      NewToken(TokenName, ClusterName, TokenTypeKube),
+			expectedToken:      NewToken(TokenName, ClusterName, []string{"kube"}),
 			expectClientErrors: false,
 		},
 		{
 			name: "case 5: Fail to return expected token",
 			config: FakeTeleportClientConfig{
 				Tokens: []types.ProvisionToken{
-					NewToken(TokenName, ClusterName, TokenTypeKube),
+					NewToken(TokenName, ClusterName, []string{"kube"}),
 				},
 			},
 			tokenName:          NewTokenName,
@@ -87,14 +87,14 @@ func Test_FakeTeleportClient(t *testing.T) {
 		{
 			name:               "case 6: Store token",
 			config:             FakeTeleportClientConfig{},
-			storedToken:        NewToken(TokenName, ClusterName, TokenTypeKube),
+			storedToken:        NewToken(TokenName, ClusterName, []string{"kube"}),
 			expectClientErrors: false,
 			expectTokensError:  false,
 		},
 		{
 			name:               "case 7: Upsert token",
 			config:             FakeTeleportClientConfig{},
-			upsertedToken:      NewToken(TokenName, ClusterName, TokenTypeNode),
+			upsertedToken:      NewToken(TokenName, ClusterName, []string{"node"}),
 			expectClientErrors: false,
 			expectTokensError:  false,
 		},
@@ -128,7 +128,7 @@ func Test_FakeTeleportClient(t *testing.T) {
 				}
 			}
 
-			token = NewToken(uuid.NewString(), ClusterName, TokenTypeKube)
+			token = NewToken(uuid.NewString(), ClusterName, []string{"kube"})
 			err = fakeClient.CreateToken(ctx, token)
 			CheckError(t, tc.expectClientErrors, err)
 

--- a/main.go
+++ b/main.go
@@ -20,13 +20,11 @@ import (
 	"context"
 	"flag"
 	"os"
-	"strconv"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 
 	appv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
-	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -41,6 +39,7 @@ import (
 
 	"github.com/giantswarm/teleport-operator/internal/controller"
 	"github.com/giantswarm/teleport-operator/internal/pkg/config"
+	"github.com/giantswarm/teleport-operator/internal/pkg/key"
 	"github.com/giantswarm/teleport-operator/internal/pkg/teleport"
 	"github.com/giantswarm/teleport-operator/internal/pkg/token"
 	//+kubebuilder:scaffold:imports
@@ -59,13 +58,14 @@ func init() {
 
 	//+kubebuilder:scaffold:scheme
 }
-
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var enableTeleportBot bool
 	var probeAddr string
 	var namespace string
+	var tokenRolesStr string
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -75,12 +75,21 @@ func main() {
 		"Enable teleport bot for teleport-operator. "+
 			"Enabling this will ensure teleport bot configmap is created and app.spec.extraConfig is updated.")
 	flag.StringVar(&namespace, "namespace", "", "Namespace where operator is deployed")
+	flag.StringVar(&tokenRolesStr, "token-roles", "kube", "Comma-separated list of roles for the token (kube, app, node)")
+
 	opts := zap.Options{
-		Development: false,
-		TimeEncoder: zapcore.ISO8601TimeEncoder,
+		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	tokenRoles, err := key.ParseRoles(tokenRolesStr)
+	if err != nil {
+		setupLog.Error(err, "Failed to parse token roles")
+		os.Exit(1)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -122,19 +131,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	useCombinedTokens, err := strconv.ParseBool(os.Getenv("USE_COMBINED_TOKENS"))
-	if err != nil {
-		useCombinedTokens = false
-	}
 	tele := teleport.New(namespace, config, token.NewGenerator())
 	if err = (&controller.ClusterReconciler{
-		Client:            mgr.GetClient(),
-		Log:               ctrl.Log.WithName("controllers").WithName("Cluster"),
-		Scheme:            mgr.GetScheme(),
-		Teleport:          tele,
-		IsBotEnabled:      enableTeleportBot,
-		Namespace:         namespace,
-		UseCombinedTokens: useCombinedTokens,
+		Client:       mgr.GetClient(),
+		Log:          ctrl.Log.WithName("controllers").WithName("Cluster"),
+		Scheme:       mgr.GetScheme(),
+		Teleport:     tele,
+		IsBotEnabled: enableTeleportBot,
+		Namespace:    namespace,
+		TokenRoles:   tokenRoles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"os"
+	"strconv"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -121,14 +122,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	useCombinedTokens, err := strconv.ParseBool(os.Getenv("USE_COMBINED_TOKENS"))
+	if err != nil {
+		useCombinedTokens = false
+	}
 	tele := teleport.New(namespace, config, token.NewGenerator())
 	if err = (&controller.ClusterReconciler{
-		Client:       mgr.GetClient(),
-		Log:          ctrl.Log.WithName("controllers").WithName("Cluster"),
-		Scheme:       mgr.GetScheme(),
-		Teleport:     tele,
-		IsBotEnabled: enableTeleportBot,
-		Namespace:    namespace,
+		Client:            mgr.GetClient(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Cluster"),
+		Scheme:            mgr.GetScheme(),
+		Teleport:          tele,
+		IsBotEnabled:      enableTeleportBot,
+		Namespace:         namespace,
+		UseCombinedTokens: useCombinedTokens,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		os.Exit(1)


### PR DESCRIPTION
### What this PR does / why we need it

- This PR adds the option to generate more than one type of tokens combined currently supports: node, kube & app.

### Checklist

- [x] Update changelog in CHANGELOG.md.
