### PR TITLE
Mc namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-
+- Implemented `MC-Namespace` flag to avoid enabling roles except `kube` to workload clusters
 - Increased `grpc buffer` size
 
 ## [0.11.1] - 2024-10-11

--- a/helm/teleport-operator/templates/deployment.yaml
+++ b/helm/teleport-operator/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         args:
         - "--namespace={{ include "resource.default.namespace" . }}"
         - "--token-roles={{ .Values.teleportOperator.roles | join "," }}"
+        - "--mc-namespace={{ .Values.teleportOperator.mcNamespace }}"
         {{- if .Values.tbot.enabled }}
         - "--tbot"
         {{- end }}

--- a/helm/teleport-operator/values.yaml
+++ b/helm/teleport-operator/values.yaml
@@ -22,6 +22,7 @@ teleport:
 teleportOperator:
   roles:
     - kube
+  mcNamespace: "org-giantswarm"
 
 pod:
   user:

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -249,7 +249,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// We need to requeue to check the teleport token validity
 	// and update secret for the cluster, if it expires
-	return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -207,7 +207,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.Teleport.CreateConfigMap(ctx, log, r.Client, cluster.Name, cluster.Namespace, registerName, token, roles); err != nil {
 			return ctrl.Result{}, microerror.Mask(err)
 		}
-		log.Info("Created new config map with teleport kube join token", "configMapName", key.GetConfigmapName(cluster.Name, r.Teleport.Config.AppName))
+		log.Info("Created new config map with teleport join token", "configMapName", key.GetConfigmapName(cluster.Name, r.Teleport.Config.AppName), "roles", roles)
 	} else {
 		token, err := r.Teleport.GetTokenFromConfigMap(ctx, configMap)
 		if err != nil {
@@ -225,9 +225,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if err := r.Teleport.UpdateConfigMap(ctx, log, r.Client, configMap, newToken, roles); err != nil {
 				return ctrl.Result{}, microerror.Mask(err)
 			}
-			log.Info("Updated config map with new teleport kube join token", "configMapName", configMap.GetName())
+			log.Info("Updated config map with new teleport join token", "configMapName", configMap.GetName(), "roles", roles)
 		} else {
-			log.Info("ConfigMap has valid teleport kube join token", "configMapName", configMap.GetName())
+			log.Info("ConfigMap has valid teleport join token", "configMapName", configMap.GetName(), "roles", roles)
 		}
 	}
 

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -39,6 +39,8 @@ func Test_ClusterController(t *testing.T) {
 		expectedSecret    *corev1.Secret
 		expectedConfigMap *corev1.ConfigMap
 		expectedError     error
+		mcNamespace       string
+		tokenRoles        []string
 	}{
 		{
 			name:              "case 0: Register cluster and create Secret, ConfigMap and App resources in case they do not exist",
@@ -49,20 +51,21 @@ func Test_ClusterController(t *testing.T) {
 			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
+			tokenRoles:        []string{key.RoleKube, key.RoleApp},
 		},
 		{
-			name:              "case 1: Register cluster and update Secret, ConfigMap and App resources in case they exist",
+			name:              "case 1: Register cluster in MC namespace and create Secret, ConfigMap with TokenRoles",
 			namespace:         test.NamespaceName,
 			token:             test.TokenName,
 			config:            newConfig(),
 			identity:          newIdentity(test.LastReadValue),
 			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
-			secret:            test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube, key.RoleApp}),
+			mcNamespace:       test.NamespaceName,
+			tokenRoles:        []string{key.RoleKube, key.RoleApp},
 		},
 		{
 			name:              "case 2: Update Secret and ConfigMap resources in case join token changes",
@@ -72,20 +75,22 @@ func Test_ClusterController(t *testing.T) {
 			identity:          newIdentity(test.LastReadValue),
 			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			secret:            test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.NewTokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{"kube", "app"}),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{key.RoleKube}),
+			tokenRoles:        []string{key.RoleKube, key.RoleApp},
 		},
 		{
-			name:      "case 3: Deregister cluster and delete resources in case the cluster is deleted",
-			namespace: test.NamespaceName,
-			token:     test.TokenName,
-			config:    newConfig(),
-			identity:  newIdentity(test.LastReadValue),
-			cluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Now()),
-			secret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			name:       "case 3: Deregister cluster and delete resources in case the cluster is deleted",
+			namespace:  test.NamespaceName,
+			token:      test.TokenName,
+			config:     newConfig(),
+			identity:   newIdentity(test.LastReadValue),
+			cluster:    test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Now()),
+			secret:     test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
+			configMap:  test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
+			tokenRoles: []string{key.RoleKube, key.RoleApp},
 		},
 		{
 			name:           "case 4: Reconnect to Teleport when credentials are rotated",
@@ -96,13 +101,14 @@ func Test_ClusterController(t *testing.T) {
 			cluster:        test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			secret:         test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
 			identitySecret: test.NewIdentitySecret(test.NamespaceName, test.IdentityFileValue),
-			configMap:      test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMap:      test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
 			newTeleportClient: func(ctx context.Context, proxyAddr, identityFile string) (teleport.Client, error) {
 				return test.NewTeleportClient(test.FakeTeleportClientConfig{Tokens: nil}), nil
 			},
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.NewTokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{"kube", "app"}),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{key.RoleKube}),
+			tokenRoles:        []string{key.RoleKube, key.RoleApp},
 		},
 		{
 			name:      "case 5: Return an error in case reconnection to Teleport fails after the credentials are rotated",
@@ -112,11 +118,12 @@ func Test_ClusterController(t *testing.T) {
 			identity:  newIdentity(time.Now().Add(-identityExpirationPeriod - time.Second)),
 			cluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			secret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{"kube", "app"}),
+			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
 			newTeleportClient: func(ctx context.Context, proxyAddr, identityFile string) (teleport.Client, error) {
 				return nil, errors.New("simulated error")
 			},
 			expectedError: errors.New("secrets \"identity-output\" not found"),
+			tokenRoles:    []string{key.RoleKube, key.RoleApp},
 		},
 	}
 
@@ -159,7 +166,8 @@ func Test_ClusterController(t *testing.T) {
 				Namespace:    tc.namespace,
 				Teleport:     teleport.New(tc.namespace, tc.config, test.NewMockTokenGenerator(tc.token)),
 				IsBotEnabled: false,
-				TokenRoles:   []string{"kube", "app"},
+				TokenRoles:   tc.tokenRoles,
+				MCNamespace:  tc.mcNamespace,
 			}
 			controller.Teleport.TeleportClient = test.NewTeleportClient(test.FakeTeleportClientConfig{
 				Tokens: tc.tokens,

--- a/internal/pkg/teleport/token.go
+++ b/internal/pkg/teleport/token.go
@@ -12,14 +12,17 @@ import (
 	"github.com/giantswarm/teleport-operator/internal/pkg/key"
 )
 
-func (t *Teleport) IsTokenValid(ctx context.Context, registerName string, oldToken string, tokenType string) (bool, error) {
+func (t *Teleport) IsTokenValid(ctx context.Context, registerName string, token string, tokenType string) (bool, error) {
 	tokens, err := t.TeleportClient.GetTokens(ctx)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}
-	for _, token := range tokens {
-		if token.GetMetadata().Labels["cluster"] == registerName && token.GetMetadata().Labels["type"] == tokenType {
-			if token.GetName() == oldToken {
+
+	for _, t := range tokens {
+		if t.GetName() == token &&
+			t.GetMetadata().Labels["cluster"] == registerName &&
+			t.GetMetadata().Labels["type"] == tokenType {
+			if t.Expiry().After(time.Now()) {
 				return true, nil
 			}
 			return false, nil

--- a/internal/pkg/teleport/token_test.go
+++ b/internal/pkg/teleport/token_test.go
@@ -118,15 +118,15 @@ func Test_IsTokenValid(t *testing.T) {
 		expectedResult bool
 	}{
 		{
-			name:           "case 0: Service should return true in case the token exists",
+			name:           "case 0: Service should return true for a valid, non-expired token",
 			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			tokenName:      test.TokenName,
 			tokenType:      test.TokenTypeKube,
-			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"})},
+			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"}, time.Now().Add(1*time.Hour))},
 			expectedResult: true,
 		},
 		{
-			name:           "case 1: Service should return false in case the token does not exist",
+			name:           "case 1: Service should return false for a non-existent token",
 			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			tokenName:      test.TokenName,
 			tokenType:      test.TokenTypeKube,
@@ -134,7 +134,7 @@ func Test_IsTokenValid(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			name:           "case 2: Service should return false in case the token types do not match",
+			name:           "case 2: Service should return false for a token with mismatched type",
 			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			tokenName:      test.TokenName,
 			tokenType:      test.TokenTypeNode,
@@ -142,12 +142,28 @@ func Test_IsTokenValid(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			name:         "case 3: Service should fail in case the token cannot be retrieved",
+			name:         "case 3: Service should fail when token list cannot be retrieved",
 			registerName: key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
 			tokenName:    test.TokenName,
 			tokenType:    test.TokenTypeKube,
 			failsList:    true,
 			expectError:  true,
+		},
+		{
+			name:           "case 4: Service should return false for an expired token",
+			registerName:   key.GetRegisterName(test.ManagementClusterName, test.ClusterName),
+			tokenName:      test.TokenName,
+			tokenType:      test.TokenTypeKube,
+			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"}, time.Now().Add(-1*time.Hour))},
+			expectedResult: false,
+		},
+		{
+			name:           "case 5: Service should return false for a token with mismatched cluster name",
+			registerName:   key.GetRegisterName(test.ManagementClusterName, "wrong-cluster"),
+			tokenName:      test.TokenName,
+			tokenType:      test.TokenTypeKube,
+			tokens:         []types.ProvisionToken{test.NewToken(test.TokenName, test.ClusterName, []string{"kube"}, time.Now().Add(1*time.Hour))},
+			expectedResult: false,
 		},
 	}
 

--- a/internal/pkg/test/resources.go
+++ b/internal/pkg/test/resources.go
@@ -101,7 +101,7 @@ func NewToken(tokenName, clusterName string, roles []string, expiry ...time.Time
 	if len(expiry) > 0 {
 		expiryTime = expiry[0]
 	} else {
-		expiryTime = time.Now().Add(24 * time.Hour) // Default to 24 hours from now
+		expiryTime = time.Now().Add(720 * time.Hour)
 	}
 
 	newToken := &types.ProvisionTokenV2{

--- a/internal/pkg/test/resources.go
+++ b/internal/pkg/test/resources.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	appv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	"github.com/gravitational/teleport/api/types"
 	teleportTypes "github.com/gravitational/teleport/api/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,27 +96,35 @@ func NewConfigMap(clusterName, appName, namespaceName, tokenName string, roles [
 	}
 }
 
-func NewToken(tokenName, clusterName string, roles []string) teleportTypes.ProvisionToken {
-	newToken := &teleportTypes.ProvisionTokenV2{
-		Metadata: teleportTypes.Metadata{
+func NewToken(tokenName, clusterName string, roles []string, expiry ...time.Time) types.ProvisionToken {
+	var expiryTime time.Time
+	if len(expiry) > 0 {
+		expiryTime = expiry[0]
+	} else {
+		expiryTime = time.Now().Add(24 * time.Hour) // Default to 24 hours from now
+	}
+
+	newToken := &types.ProvisionTokenV2{
+		Metadata: types.Metadata{
 			Name: tokenName,
 			Labels: map[string]string{
 				ClusterKey:   key.GetRegisterName(ManagementClusterName, clusterName),
 				TokenTypeKey: strings.Join(roles, ","),
 			},
+			Expires: &expiryTime,
 		},
-		Spec: teleportTypes.ProvisionTokenSpecV2{
-			Roles: []teleportTypes.SystemRole{},
+		Spec: types.ProvisionTokenSpecV2{
+			Roles: []types.SystemRole{},
 		},
 	}
 	for _, role := range roles {
 		switch role {
 		case key.RoleKube:
-			newToken.Spec.Roles = append(newToken.Spec.Roles, teleportTypes.RoleKube)
+			newToken.Spec.Roles = append(newToken.Spec.Roles, types.RoleKube)
 		case key.RoleApp:
-			newToken.Spec.Roles = append(newToken.Spec.Roles, teleportTypes.RoleApp)
+			newToken.Spec.Roles = append(newToken.Spec.Roles, types.RoleApp)
 		case key.RoleNode:
-			newToken.Spec.Roles = append(newToken.Spec.Roles, teleportTypes.RoleNode)
+			newToken.Spec.Roles = append(newToken.Spec.Roles, types.RoleNode)
 		}
 	}
 	return newToken


### PR DESCRIPTION
### What this PR does / why we need it

- Implements `MC-Namespace` flag to avoid enabling roles except `kube` to workload clusters

### Checklist

- [x] Update changelog in CHANGELOG.md.
