### PR TITLE
cm iteration logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed the logic of setting roles by parsing `"%s-teleport-kube-agent-user-values"` configmaps to check if apps are enabled.
+- Deprecated `MC-Namespace` and `tokenRoles`
+
 ## [0.11.2] - 2024-10-11
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/gomega v1.34.1
 	github.com/pkg/errors v0.9.1
 	google.golang.org/grpc v1.67.1
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
@@ -107,7 +108,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect

--- a/helm/teleport-operator/templates/deployment.yaml
+++ b/helm/teleport-operator/templates/deployment.yaml
@@ -36,8 +36,6 @@ spec:
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Chart.Version }}"
         args:
         - "--namespace={{ include "resource.default.namespace" . }}"
-        - "--token-roles={{ .Values.teleportOperator.roles | join "," }}"
-        - "--mc-namespace={{ .Values.teleportOperator.mcNamespace }}"
         {{- if .Values.tbot.enabled }}
         - "--tbot"
         {{- end }}

--- a/helm/teleport-operator/values.schema.json
+++ b/helm/teleport-operator/values.schema.json
@@ -63,19 +63,6 @@
                 }
             }
         },
-        "teleportOperator": {
-            "type": "object",
-            "properties": {
-              "roles": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "List of roles for the Teleport operator. Example: ['kube', 'app']"
-              }
-            },
-            "required": ["roles"]
-          },
         "pod": {
             "type": "object",
             "properties": {

--- a/helm/teleport-operator/values.yaml
+++ b/helm/teleport-operator/values.yaml
@@ -19,10 +19,6 @@ teleport:
   teleportClusterName: test.teleport.giantswarm.io
   teleportVersion: 16.1.7
 
-teleportOperator:
-  roles:
-    - kube
-  mcNamespace: "org-giantswarm"
 
 pod:
   user:

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -3,12 +3,15 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	appv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	teleportTypes "github.com/gravitational/teleport/api/types"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -24,26 +27,68 @@ import (
 
 func Test_ClusterController(t *testing.T) {
 	testCases := []struct {
-		name              string
-		namespace         string
-		token             string
-		tokens            []teleportTypes.ProvisionToken
-		config            *config.Config
-		identity          *config.IdentityConfig
-		identitySecret    *corev1.Secret
-		cluster           *capi.Cluster
-		secret            *corev1.Secret
-		configMap         *corev1.ConfigMap
-		newTeleportClient func(ctx context.Context, proxyAddr, identityFile string) (teleport.Client, error)
-		expectedCluster   *capi.Cluster
-		expectedSecret    *corev1.Secret
-		expectedConfigMap *corev1.ConfigMap
-		expectedError     error
-		mcNamespace       string
-		tokenRoles        []string
+		name                string
+		namespace           string
+		token               string
+		tokens              []teleportTypes.ProvisionToken
+		config              *config.Config
+		identity            *config.IdentityConfig
+		identitySecret      *corev1.Secret
+		cluster             *capi.Cluster
+		secret              *corev1.Secret
+		configMap           *corev1.ConfigMap
+		userValuesConfigMap *corev1.ConfigMap
+		newTeleportClient   func(ctx context.Context, proxyAddr, identityFile string) (teleport.Client, error)
+		expectedCluster     *capi.Cluster
+		expectedSecret      *corev1.Secret
+		expectedConfigMap   *corev1.ConfigMap
+		expectedError       error
+		expectedRoles       []string
 	}{
 		{
-			name:              "case 0: Register cluster and create Secret, ConfigMap and App resources in case they do not exist",
+			name:      "case 0: Register cluster with apps enabled",
+			namespace: test.NamespaceName,
+			token:     test.TokenName,
+			config:    newConfig(),
+			identity:  newIdentity(test.LastReadValue),
+			cluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
+			userValuesConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-teleport-kube-agent-user-values", test.ClusterName),
+					Namespace: test.NamespaceName,
+				},
+				Data: map[string]string{
+					"values": "apps:\n- name: test-app\n  uri: http://test-app",
+				},
+			},
+			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
+			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube, key.RoleApp}),
+			expectedRoles:     []string{key.RoleKube, key.RoleApp},
+		},
+		{
+			name:      "case 1: Register cluster without apps",
+			namespace: test.NamespaceName,
+			token:     test.TokenName,
+			config:    newConfig(),
+			identity:  newIdentity(test.LastReadValue),
+			cluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
+			userValuesConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-teleport-kube-agent-user-values", test.ClusterName),
+					Namespace: test.NamespaceName,
+				},
+				Data: map[string]string{
+					"values": "someOtherConfig: true",
+				},
+			},
+			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
+			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
+			expectedRoles:     []string{key.RoleKube},
+		},
+		{
+			name:              "case 2: Register cluster without user values ConfigMap",
 			namespace:         test.NamespaceName,
 			token:             test.TokenName,
 			config:            newConfig(),
@@ -52,48 +97,44 @@ func Test_ClusterController(t *testing.T) {
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
 			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
-			tokenRoles:        []string{key.RoleKube, key.RoleApp},
+			expectedRoles:     []string{key.RoleKube},
 		},
 		{
-			name:              "case 1: Register cluster in MC namespace and create Secret, ConfigMap with TokenRoles",
-			namespace:         test.NamespaceName,
-			token:             test.TokenName,
-			config:            newConfig(),
-			identity:          newIdentity(test.LastReadValue),
-			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
-			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
-			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube, key.RoleApp}),
-			mcNamespace:       test.NamespaceName,
-			tokenRoles:        []string{key.RoleKube, key.RoleApp},
-		},
-		{
-			name:              "case 2: Update Secret and ConfigMap resources in case join token changes",
-			namespace:         test.NamespaceName,
-			token:             test.NewTokenName,
-			config:            newConfig(),
-			identity:          newIdentity(test.LastReadValue),
-			cluster:           test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
-			secret:            test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap:         test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
+			name:      "case 3: Update Secret and ConfigMap resources in case join token changes",
+			namespace: test.NamespaceName,
+			token:     test.NewTokenName,
+			config:    newConfig(),
+			identity:  newIdentity(test.LastReadValue),
+			cluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
+			secret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
+			configMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
+			userValuesConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-teleport-kube-agent-user-values", test.ClusterName),
+					Namespace: test.NamespaceName,
+				},
+				Data: map[string]string{
+					"values": "apps:\n- name: test-app\n  uri: http://test-app",
+				},
+			},
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.NewTokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{key.RoleKube}),
-			tokenRoles:        []string{key.RoleKube, key.RoleApp},
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{key.RoleKube, key.RoleApp}),
+			expectedRoles:     []string{key.RoleKube, key.RoleApp},
 		},
 		{
-			name:       "case 3: Deregister cluster and delete resources in case the cluster is deleted",
-			namespace:  test.NamespaceName,
-			token:      test.TokenName,
-			config:     newConfig(),
-			identity:   newIdentity(test.LastReadValue),
-			cluster:    test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Now()),
-			secret:     test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
-			configMap:  test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
-			tokenRoles: []string{key.RoleKube, key.RoleApp},
+			name:          "case 4: Deregister cluster and delete resources in case the cluster is deleted",
+			namespace:     test.NamespaceName,
+			token:         test.TokenName,
+			config:        newConfig(),
+			identity:      newIdentity(test.LastReadValue),
+			cluster:       test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Now()),
+			secret:        test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
+			configMap:     test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
+			expectedRoles: []string{key.RoleKube},
 		},
 		{
-			name:           "case 4: Reconnect to Teleport when credentials are rotated",
+			name:           "case 5: Reconnect to Teleport when credentials are rotated",
 			namespace:      test.NamespaceName,
 			token:          test.NewTokenName,
 			config:         newConfig(),
@@ -102,16 +143,25 @@ func Test_ClusterController(t *testing.T) {
 			secret:         test.NewSecret(test.ClusterName, test.NamespaceName, test.TokenName),
 			identitySecret: test.NewIdentitySecret(test.NamespaceName, test.IdentityFileValue),
 			configMap:      test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.TokenName, []string{key.RoleKube}),
+			userValuesConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-teleport-kube-agent-user-values", test.ClusterName),
+					Namespace: test.NamespaceName,
+				},
+				Data: map[string]string{
+					"values": "apps:\n- name: test-app\n  uri: http://test-app",
+				},
+			},
 			newTeleportClient: func(ctx context.Context, proxyAddr, identityFile string) (teleport.Client, error) {
 				return test.NewTeleportClient(test.FakeTeleportClientConfig{Tokens: nil}), nil
 			},
 			expectedCluster:   test.NewCluster(test.ClusterName, test.NamespaceName, []string{key.TeleportOperatorFinalizer}, time.Time{}),
 			expectedSecret:    test.NewSecret(test.ClusterName, test.NamespaceName, test.NewTokenName),
-			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{key.RoleKube}),
-			tokenRoles:        []string{key.RoleKube, key.RoleApp},
+			expectedConfigMap: test.NewConfigMap(test.ClusterName, test.AppName, test.NamespaceName, test.NewTokenName, []string{key.RoleKube, key.RoleApp}),
+			expectedRoles:     []string{key.RoleKube, key.RoleApp},
 		},
 		{
-			name:      "case 5: Return an error in case reconnection to Teleport fails after the credentials are rotated",
+			name:      "case 6: Return an error in case reconnection to Teleport fails after the credentials are rotated",
 			namespace: test.NamespaceName,
 			token:     test.TokenName,
 			config:    newConfig(),
@@ -123,7 +173,7 @@ func Test_ClusterController(t *testing.T) {
 				return nil, errors.New("simulated error")
 			},
 			expectedError: errors.New("secrets \"identity-output\" not found"),
-			tokenRoles:    []string{key.RoleKube, key.RoleApp},
+			expectedRoles: []string{key.RoleKube},
 		},
 	}
 
@@ -141,6 +191,9 @@ func Test_ClusterController(t *testing.T) {
 			}
 			if tc.identitySecret != nil {
 				runtimeObjects = append(runtimeObjects, tc.identitySecret)
+			}
+			if tc.userValuesConfigMap != nil {
+				runtimeObjects = append(runtimeObjects, tc.userValuesConfigMap)
 			}
 
 			newTeleportClient := teleport.NewClient
@@ -166,13 +219,12 @@ func Test_ClusterController(t *testing.T) {
 				Namespace:    tc.namespace,
 				Teleport:     teleport.New(tc.namespace, tc.config, test.NewMockTokenGenerator(tc.token)),
 				IsBotEnabled: false,
-				TokenRoles:   tc.tokenRoles,
-				MCNamespace:  tc.mcNamespace,
 			}
 			controller.Teleport.TeleportClient = test.NewTeleportClient(test.FakeTeleportClientConfig{
 				Tokens: tc.tokens,
 			})
 			controller.Teleport.Identity = tc.identity
+			controller.Teleport.Client = ctrlClient
 
 			req := ctrl.Request{
 				NamespacedName: types.NamespacedName{
@@ -245,8 +297,19 @@ func Test_ClusterController(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
+
+			// Check if the roles were set correctly
+			// This assumes you've added a method to expose the last assigned roles for testing
+			assignedRoles := controller.GetLastAssignedRoles()
+			if !reflect.DeepEqual(assignedRoles, tc.expectedRoles) {
+				t.Errorf("Expected roles %v, but got %v", tc.expectedRoles, assignedRoles)
+			}
 		})
 	}
+}
+
+func (r *ClusterReconciler) GetLastAssignedRoles() []string {
+	return r.lastAssignedRoles
 }
 
 func newConfig() *config.Config {

--- a/internal/pkg/teleport/teleport.go
+++ b/internal/pkg/teleport/teleport.go
@@ -1,6 +1,15 @@
 package teleport
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/giantswarm/teleport-operator/internal/pkg/config"
 	"github.com/giantswarm/teleport-operator/internal/pkg/token"
 )
@@ -11,6 +20,7 @@ type Teleport struct {
 	TeleportClient Client
 	Namespace      string
 	TokenGenerator token.Generator
+	Client         client.Client
 }
 
 func New(namespace string, cfg *config.Config, tokenGenerator token.Generator) *Teleport {
@@ -19,4 +29,33 @@ func New(namespace string, cfg *config.Config, tokenGenerator token.Generator) *
 		Namespace:      namespace,
 		TokenGenerator: tokenGenerator,
 	}
+}
+
+func (t *Teleport) AreTeleportAppsEnabled(ctx context.Context, clusterName, namespace string) (bool, error) {
+	configMap := &corev1.ConfigMap{}
+	err := t.Client.Get(ctx, types.NamespacedName{
+		Name:      fmt.Sprintf("%s-teleport-kube-agent-user-values", clusterName),
+		Namespace: namespace,
+	}, configMap)
+
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return false, microerror.Mask(err)
+		}
+		return false, nil // ConfigMap not found, return false without error
+	}
+
+	valuesYaml, ok := configMap.Data["values"]
+	if !ok {
+		return false, nil // No values key, apps are not enabled
+	}
+
+	var values map[string]interface{}
+	err = yaml.Unmarshal([]byte(valuesYaml), &values)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	apps, ok := values["apps"].([]interface{})
+	return ok && len(apps) > 0, nil
 }

--- a/main.go
+++ b/main.go
@@ -63,8 +63,6 @@ func main() {
 	var enableTeleportBot bool
 	var probeAddr string
 	var namespace string
-	var tokenRolesStr string
-	var mcNamespace string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -75,8 +73,6 @@ func main() {
 		"Enable teleport bot for teleport-operator. "+
 			"Enabling this will ensure teleport bot configmap is created and app.spec.extraConfig is updated.")
 	flag.StringVar(&namespace, "namespace", "", "Namespace where operator is deployed")
-	flag.StringVar(&tokenRolesStr, "token-roles", "kube", "Comma-separated list of roles for the token (kube, app, node)")
-	flag.StringVar(&mcNamespace, "mc-namespace", "", "Namespace for management cluster with additional roles")
 
 	opts := zap.Options{
 		Development: true,
@@ -151,7 +147,6 @@ func main() {
 	}
 
 	setupLog.Info("is teleport bot enabled?", "enabled", enableTeleportBot)
-	setupLog.Info("management cluster namespace", "namespace", mcNamespace)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
### What this PR does / why we need it

- Changes the logic of setting roles by parsing `"%s-teleport-kube-agent-user-values"` configmaps to check if apps are enabled.
- Deprecates `MC-Namespace` and `tokenRoles`

### Checklist

- [x] Update changelog in CHANGELOG.md.
